### PR TITLE
Rename help function to print_help

### DIFF
--- a/main.py
+++ b/main.py
@@ -263,9 +263,9 @@ async def main():
     # Get user input for channels and parameters
     initial_channels_input = input("\nEnter comma-separated Telegram Channel(s) (or type 'help'): ")
 
-    # Run the help function then prompt user if requested
+    # Run the print_help function then prompt user if requested
     if initial_channels_input.lower() == "help":
-        help()
+        print_help()
         initial_channels_input = input("\nEnter Telegram Channel(s): ")
 
     initial_channels = [channel.strip() for channel in initial_channels_input.split(',') if channel.strip()]

--- a/utils.py
+++ b/utils.py
@@ -284,8 +284,8 @@ def update_env_file(env_file_path, api_id, api_hash):
             logger.error(f"Failed to create .env file: {inner_e}")
 
 
-def help():
-    """Display help information about the tool"""
+def print_help() -> None:
+    """Display help information about the tool."""
     printC('''----
     HELP
     ----


### PR DESCRIPTION
## Summary
- rename `help` utility function to `print_help`
- update main to call new `print_help`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from utils import *
print(help)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adc7fd95108324bb56c6df5a35cb63