### PR TITLE
Add unit tests for CSV merging and edge list creation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_edge_list.py
+++ b/tests/test_edge_list.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from EdgeList import create_edge_list
+
+
+def test_create_edge_list_writes_header_and_appends(tmp_path: Path) -> None:
+    folder = tmp_path / 'edges'
+    create_edge_list(
+        folder_name=str(folder),
+        file_name='edges.csv',
+        from_channel_id=1,
+        from_channel_name='A',
+        from_channel_username='a',
+        to_channel_id=2,
+        to_channel_name='B',
+        to_channel_username='b',
+        connection_type='forward',
+        weight=1,
+    )
+    create_edge_list(
+        folder_name=str(folder),
+        file_name='edges.csv',
+        from_channel_id=3,
+        from_channel_name='C',
+        from_channel_username='c',
+        to_channel_id=4,
+        to_channel_name='D',
+        to_channel_username='d',
+        connection_type='recommendation',
+        weight=2,
+    )
+
+    with (folder / 'edges.csv').open(newline='', encoding='utf-8') as file:
+        reader = list(csv.reader(file))
+
+    assert reader[0] == [
+        'From_Channel_ID',
+        'From_Channel_Name',
+        'From_Channel_Username',
+        'To_Channel_ID',
+        'To_Channel_Name',
+        'To_Channel_Username',
+        'ConnectionType',
+        'Weight',
+    ]
+    assert reader[1] == ['1', 'A', 'a', '2', 'B', 'b', 'forward', '1']
+    assert reader[2] == ['3', 'C', 'c', '4', 'D', 'd', 'recommendation', '2']

--- a/tests/test_merge_csv_files.py
+++ b/tests/test_merge_csv_files.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from merge_csv_data import merge_csv_files
+
+
+def write_csv(path: Path, rows: list[list[str]]) -> None:
+    with path.open('w', newline='', encoding='utf-8') as file:
+        writer = csv.writer(file)
+        writer.writerow(['Channel ID', 'Channel Name', 'Channel Username'])
+        writer.writerows(rows)
+
+
+def test_merge_csv_files_deduplicates(tmp_path: Path) -> None:
+    results_dir = tmp_path / 'results'
+    merged_dir = tmp_path / 'merged'
+    results_dir.mkdir()
+    merged_dir.mkdir()
+
+    write_csv(
+        results_dir / 'file1.csv',
+        [['1', 'ChannelA', 'usera'], ['2', 'ChannelB', 'userb']],
+    )
+    write_csv(
+        results_dir / 'file2.csv',
+        [['2', 'ChannelB', 'userb'], ['3', 'ChannelC', 'userc']],
+    )
+
+    merge_csv_files(
+        str(results_dir),
+        str(merged_dir),
+        'merged_channels.csv',
+        '',
+    )
+
+    with (merged_dir / 'merged_channels.csv').open(newline='', encoding='utf-8') as file:
+        reader = list(csv.reader(file))
+
+    assert reader[0] == ['Channel ID', 'Channel Name', 'Channel Username']
+    assert sorted(reader[1:]) == [
+        ['1', 'ChannelA', 'usera'],
+        ['2', 'ChannelB', 'userb'],
+        ['3', 'ChannelC', 'userc'],
+    ]


### PR DESCRIPTION
## Summary
- add pytest configuration and tests
- cover merge_csv_files duplicate removal and merging
- verify create_edge_list header creation and row appending

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc7f9aef48324938521bc4a5412b2