### PR TITLE
refactor: remove unused main_directory_csv parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -381,8 +381,7 @@ if __name__ == '__main__':
         merge_csv_files(
             Config.RESULTS_FOLDER,
             Config.MERGED_FOLDER,
-            Config.MERGED_FILENAME,
-            "channels.csv"
+            Config.MERGED_FILENAME
         )
         print('Process Complete.')
 

--- a/merge_csv_data.py
+++ b/merge_csv_data.py
@@ -2,7 +2,16 @@ import os
 import pandas as pd
 import csv
 
-def merge_csv_files(results_folder, merged_folder, merged_filename, main_directory_csv):
+
+def merge_csv_files(results_folder: str, merged_folder: str, merged_filename: str) -> None:
+    """Merge CSV files from the results directory into a deduplicated CSV.
+
+    Args:
+        results_folder: Directory containing individual result CSV files.
+        merged_folder: Directory where the merged CSV will be stored.
+        merged_filename: Name of the output merged CSV file.
+    """
+
     print('Merging and de-duplicating CSVs...')
     merged_file_path = os.path.join(merged_folder, merged_filename)
 
@@ -50,5 +59,5 @@ def merge_csv_files(results_folder, merged_folder, merged_filename, main_directo
 
 if __name__ == '__main__':
     # Specify the folders and filename
-    results_folder, merged_folder, merged_filename, main_directory_csv = 'results', 'merged', 'merged_channels.csv', 'channels.csv'
-    merge_csv_files(results_folder, merged_folder, merged_filename, main_directory_csv)  # Call the function
+    results_folder, merged_folder, merged_filename = 'results', 'merged', 'merged_channels.csv'
+    merge_csv_files(results_folder, merged_folder, merged_filename)  # Call the function


### PR DESCRIPTION
## Summary
- simplify `merge_csv_files` by removing the unused `main_directory_csv` argument
- update CLI usage in `merge_csv_data.py` and call site in `main.py`
- document new signature with type hints and docstring

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `rg main_directory_csv`

------
https://chatgpt.com/codex/tasks/task_e_68adc7f221148324b24b89ec1ae4e19e