### PR TITLE
Optimize entity retrieval with caching in process_channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,12 +34,20 @@ async def process_channels(client, csv_file_path, initial_channels, iterations, 
 
     Returns:
         tuple: Results, durations, channel counts, and total messages processed
+
+    Note:
+        Channel entities are cached to minimize redundant API calls. The current channel entity is reused
+        when iterating messages, and forwarded channel entities are stored in a dictionary cache keyed by
+        their ID.
     """
     # Initial variables defined
     processed_channels, channels_to_process = set(), deque(initial_channels)
     processed_channel_ids = set()  # Track processed channels by ID
     iteration_results, iteration_durations, mention_counter = [], [], {}
     total_messages_processed, channel_counts = 0, []
+
+    # Cache for forwarded channel entities to avoid repeated get_entity calls
+    forwarded_channel_cache: dict[int, Channel] = {}
 
     # Set up URL file if needed
     url_file = None
@@ -104,7 +112,8 @@ async def process_channels(client, csv_file_path, initial_channels, iterations, 
                     try:
                         channel_message_count = 0
 
-                        async for message in client.iter_messages(channel):
+                        # Use the previously fetched channel_entity to avoid redundant API calls
+                        async for message in client.iter_messages(channel_entity):
                             if Config.DEBUG and total_messages_processed % 100 == 0:
                                 print(f'Processing message {total_messages_processed}...', end='\r')
 
@@ -130,8 +139,12 @@ async def process_channels(client, csv_file_path, initial_channels, iterations, 
 
                                     if mention_counter[fwd_from_id_str] >= min_mentions:
                                         try:
-                                            # Get the forwarding channel's entity, name, and username
-                                            fwd_from_entity = await client.get_entity(fwd_from)
+                                            # Retrieve forwarding channel entity from cache or fetch if missing
+                                            fwd_from_entity = forwarded_channel_cache.get(fwd_from_id)
+                                            if fwd_from_entity is None:
+                                                fwd_from_entity = await client.get_entity(fwd_from)
+                                                forwarded_channel_cache[fwd_from_id] = fwd_from_entity
+
                                             fwd_from_name = getattr(fwd_from_entity, 'title', 'Unknown')
                                             fwd_from_username = getattr(fwd_from_entity, 'username', 'Unknown')
 


### PR DESCRIPTION
## Summary
- Reuse cached channel entity when iterating messages to prevent redundant API calls.
- Cache forwarded channel entities by ID, avoiding repeated `get_entity` lookups.
- Document caching strategy within `process_channels` for clarity.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68adc7ea8e688324b2c302010bb1e774