### PR TITLE
feat: support file path in edge list

### DIFF
--- a/EdgeList.py
+++ b/EdgeList.py
@@ -1,6 +1,8 @@
 import csv
 import logging
+from pathlib import Path
 from typing import TextIO, Union
+
 from config import Config
 
 # Set up logging
@@ -8,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_edge_list(
-    writer: Union[csv.writer, TextIO],
+    writer_or_path: Union[csv.writer, TextIO, str, Path],
     from_channel_id: str,
     from_channel_name: str,
     from_channel_username: str,
@@ -21,7 +23,7 @@ def create_edge_list(
     """Write a channel relationship to an edge list CSV file.
 
     Args:
-        writer: Open file handle or CSV writer used to write the edge list.
+        writer_or_path: CSV writer, open file handle, or path to the edge list file.
         from_channel_id: ID of the source channel.
         from_channel_name: Name of the source channel.
         from_channel_username: Username of the source channel.
@@ -38,17 +40,49 @@ def create_edge_list(
     to_channel_username = to_channel_username or "Unknown"
 
     try:
-        csv_writer = writer if hasattr(writer, "writerow") else csv.writer(writer)
-        csv_writer.writerow([
-            str(from_channel_id),
-            from_channel_name,
-            from_channel_username,
-            str(to_channel_id),
-            to_channel_name,
-            to_channel_username,
-            connection_type,
-            weight,
-        ])
+        if isinstance(writer_or_path, (str, Path)):
+            path = Path(writer_or_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            write_header = not path.exists() or path.stat().st_size == 0
+            with path.open("a", newline="", encoding="utf-8") as file:
+                csv_writer = csv.writer(file)
+                if write_header:
+                    csv_writer.writerow([
+                        "From_Channel_ID",
+                        "From_Channel_Name",
+                        "From_Channel_Username",
+                        "To_Channel_ID",
+                        "To_Channel_Name",
+                        "To_Channel_Username",
+                        "ConnectionType",
+                        "Weight",
+                    ])
+                csv_writer.writerow([
+                    str(from_channel_id),
+                    from_channel_name,
+                    from_channel_username,
+                    str(to_channel_id),
+                    to_channel_name,
+                    to_channel_username,
+                    connection_type,
+                    weight,
+                ])
+        else:
+            csv_writer = (
+                writer_or_path
+                if hasattr(writer_or_path, "writerow")
+                else csv.writer(writer_or_path)
+            )
+            csv_writer.writerow([
+                str(from_channel_id),
+                from_channel_name,
+                from_channel_username,
+                str(to_channel_id),
+                to_channel_name,
+                to_channel_username,
+                connection_type,
+                weight,
+            ])
         if Config.DEBUG:
             logger.debug(
                 f"Added edge: {from_channel_name} -> {to_channel_name} ({connection_type})"
@@ -57,4 +91,5 @@ def create_edge_list(
         logger.error(f"Error creating edge list entry: {e}")
         if Config.DEBUG:
             import traceback
+
             logger.error(traceback.format_exc())

--- a/tests/test_edge_list.py
+++ b/tests/test_edge_list.py
@@ -7,10 +7,9 @@ from EdgeList import create_edge_list
 
 
 def test_create_edge_list_writes_header_and_appends(tmp_path: Path) -> None:
-    folder = tmp_path / 'edges'
+    path = tmp_path / 'edges' / 'edges.csv'
     create_edge_list(
-        folder_name=str(folder),
-        file_name='edges.csv',
+        path,
         from_channel_id=1,
         from_channel_name='A',
         from_channel_username='a',
@@ -21,8 +20,7 @@ def test_create_edge_list_writes_header_and_appends(tmp_path: Path) -> None:
         weight=1,
     )
     create_edge_list(
-        folder_name=str(folder),
-        file_name='edges.csv',
+        path,
         from_channel_id=3,
         from_channel_name='C',
         from_channel_username='c',
@@ -33,7 +31,7 @@ def test_create_edge_list_writes_header_and_appends(tmp_path: Path) -> None:
         weight=2,
     )
 
-    with (folder / 'edges.csv').open(newline='', encoding='utf-8') as file:
+    with path.open(newline='', encoding='utf-8') as file:
         reader = list(csv.reader(file))
 
     assert reader[0] == [


### PR DESCRIPTION
## Summary
- allow `create_edge_list` to accept a file path or writer
- automatically create directories and add header when file path used
- update edge list test for new interface

## Testing
- `python -m py_compile EdgeList.py tests/test_edge_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfee10ad648324be19cddaa6b0b06f