### PR TITLE
Use print_help in main script

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,9 +4,9 @@ from utils import (
     attempt_connection_to_telegram,
     create_network_visualization_guide,
     final_message,
-    help,
     intro,
     printC,
+    print_help,
     retrieve_api_details,
 )
 from config import Config


### PR DESCRIPTION
## Summary
- replace unused `help` import with `print_help`
- ensure `main.py` ends with a newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfee0999c4832484fe43c86f487433