### PR TITLE
Use example_config env template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The Telegram Snowball Sampling Tool can take several days to complete its run du
 telegram-snowball-sampling/
 ├── config.py                 # Configuration manager
 ├── EdgeList.py               # Handles edge list creation
-├── example.env               # Template environment variables
-├── .env                      # Your environment variables (created from example.env)
+├── example_config.env        # Template environment variables
+├── .env                      # Your environment variables (created from example_config.env)
 ├── main.py                   # Main application script
 ├── merge_csv_data.py         # CSV merging utility
 ├── network_analysis.py       # Network analysis script

--- a/check_api_credentials.py
+++ b/check_api_credentials.py
@@ -28,7 +28,7 @@ def check_env_file() -> bool:
     if not os.path.exists(env_path):
         logger.error("Error: %s file not found!", env_path)
         logger.error("Please create a .env file with your Telegram API credentials.")
-        logger.error("Run the main.py script to automatically create one or manually copy example.env to .env")
+        logger.error("Run the main.py script to automatically create one or manually copy example_config.env to .env")
         return False
 
     # Load environment variables from .env

--- a/utils.py
+++ b/utils.py
@@ -178,13 +178,13 @@ def retrieve_api_details() -> tuple[str, str]:
     """
     # Check if .env file exists
     env_file_path = '.env'
-    example_env_path = 'example.env'
+    example_env_path = 'example_config.env'
 
     if not os.path.exists(env_file_path):
-        # No .env file, check if example.env exists
+        # No .env file, check if example_config.env exists
         if os.path.exists(example_env_path):
-            logger.info("Creating .env file from example.env template")
-            # Copy example.env to .env
+            logger.info("Creating .env file from example_config.env template")
+            # Copy example_config.env to .env
             shutil.copy2(example_env_path, env_file_path)
         else:
             # Create a basic .env file


### PR DESCRIPTION
## Summary
- reference `example_config.env` as the environment template in `retrieve_api_details`
- update documentation and credential check messaging to match new template name

## Testing
- `python -m py_compile utils.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: unexpected keyword argument 'folder_name' in `create_edge_list`; `merge_csv_files` takes 3 positional arguments but 4 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68bfee0ac6ac8324b5b444d2bdbb7ebc