### PR TITLE
Adjust merge utility imports and tests

### DIFF
--- a/merge_csv_data.py
+++ b/merge_csv_data.py
@@ -1,8 +1,8 @@
-import os
-import pandas as pd
 import csv
 import logging
+import os
 
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_merge_csv_files.py
+++ b/tests/test_merge_csv_files.py
@@ -32,7 +32,6 @@ def test_merge_csv_files_deduplicates(tmp_path: Path) -> None:
         str(results_dir),
         str(merged_dir),
         'merged_channels.csv',
-        '',
     )
 
     with (merged_dir / 'merged_channels.csv').open(newline='', encoding='utf-8') as file:


### PR DESCRIPTION
## Summary
- Reorder imports in `merge_csv_data.py` so `os` is grouped with other stdlib imports
- Call `merge_csv_files` with three arguments in its test

## Testing
- `python -m py_compile merge_csv_data.py tests/test_merge_csv_files.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfee0de3c8832499e749b0b34239e9