### PR TITLE
Organize imports in recommendations module

### DIFF
--- a/recommendations.py
+++ b/recommendations.py
@@ -1,8 +1,8 @@
-from telethon.tl.functions.channels import GetChannelRecommendationsRequest
-from telethon.errors import FloodWaitError
+import logging
 import asyncio
 import re
-import logging
+from telethon.errors import FloodWaitError
+from telethon.tl.functions.channels import GetChannelRecommendationsRequest
 from typing import Any
 
 from EdgeList import create_edge_list


### PR DESCRIPTION
## Summary
- reorder imports at the top of `recommendations.py`
- ensure file ends with a newline

## Testing
- `python -m py_compile recommendations.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfee1359708324b8fd94bd71b6cd1c